### PR TITLE
Aim assist setting

### DIFF
--- a/artifact/uobjecthook/8852081297249256682_props.json
+++ b/artifact/uobjecthook/8852081297249256682_props.json
@@ -1,0 +1,16 @@
+{
+    "hide": false,
+    "hide_legacy": false,
+    "path": [
+        "Acknowledged Pawn",
+        "Components",
+        "AimAssistComponent AimAssist"
+    ],
+    "properties": [
+        {
+            "data": 0,
+            "name": "bAimAssistEnabled"
+        }
+    ],
+    "type": "properties"
+}


### PR DESCRIPTION
Aim assist is useless in VR if a player is playing with controllers and not a gamepad. It moves the camera, which can cause motion sickness.